### PR TITLE
Travis CI: ensure testing of source code in repo

### DIFF
--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -2,7 +2,7 @@ describe("Testing cliargs library parsing commandlines", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   -- TODO, move to feature specs

--- a/spec/config_loader_spec.lua
+++ b/spec/config_loader_spec.lua
@@ -4,7 +4,7 @@ describe("cliargs.config_loader", function()
   local cli, args, err
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
     cli:flag('-q, --quiet', '...', false)
     cli:option('-c, --compress=VALUE', '...', 'lzma')
     cli:option('--config=FILE', '...', nil, function(_, path)

--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -4,7 +4,7 @@ describe("cliargs::core", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('#parse', function()

--- a/spec/features/argument_spec.lua
+++ b/spec/features/argument_spec.lua
@@ -4,7 +4,7 @@ describe("cliargs - arguments", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('defining arguments', function()

--- a/spec/features/command_spec.lua
+++ b/spec/features/command_spec.lua
@@ -2,7 +2,7 @@ describe("cliargs - commands", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('defining commands', function()

--- a/spec/features/flag_spec.lua
+++ b/spec/features/flag_spec.lua
@@ -4,7 +4,7 @@ describe("cliargs - flags", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('defining flags', function()

--- a/spec/features/integration_spec.lua
+++ b/spec/features/integration_spec.lua
@@ -4,7 +4,7 @@ describe("integration: parsing", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   it('is a no-op when no arguments or options are defined', function()

--- a/spec/features/option_spec.lua
+++ b/spec/features/option_spec.lua
@@ -4,7 +4,7 @@ describe("cliargs - options", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('defining options', function()

--- a/spec/features/splatarg_spec.lua
+++ b/spec/features/splatarg_spec.lua
@@ -4,7 +4,7 @@ describe("cliargs - splat arguments", function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('defining the splat arg', function()

--- a/spec/fixtures/test-command.lua
+++ b/spec/fixtures/test-command.lua
@@ -1,4 +1,4 @@
-local cli = require('cliargs')
+local cli = require('../src.cliargs')
 
 cli:set_name('test-command')
 cli:argument('ROOT', '...')

--- a/spec/printer_spec.lua
+++ b/spec/printer_spec.lua
@@ -5,7 +5,7 @@ describe('printer', function()
   local cli
 
   before_each(function()
-    cli = require("cliargs.core")()
+    cli = require("../src.cliargs.core")()
   end)
 
   describe('#generate_usage', function()

--- a/spec/utils/disect_argument_spec.lua
+++ b/spec/utils/disect_argument_spec.lua
@@ -1,4 +1,4 @@
-local disect_argument = require('cliargs.utils.disect_argument')
+local disect_argument = require('../src.cliargs.utils.disect_argument')
 
 require("spec_helper")
 

--- a/spec/utils/disect_spec.lua
+++ b/spec/utils/disect_spec.lua
@@ -1,4 +1,4 @@
-local disect = require('cliargs.utils.disect')
+local disect = require('../src.cliargs.utils.disect')
 
 describe("utils::disect", function()
   local function assert_disect(pattern, expected)

--- a/spec/utils/split_spec.lua
+++ b/spec/utils/split_spec.lua
@@ -1,4 +1,4 @@
-local subject = require('cliargs.utils.split')
+local subject = require('../src.cliargs.utils.split')
 
 describe("utils::split", function()
   it("should work", function()

--- a/spec/utils/wordwrap_spec.lua
+++ b/spec/utils/wordwrap_spec.lua
@@ -1,4 +1,4 @@
-local subject = require('cliargs.utils.wordwrap')
+local subject = require('../src.cliargs.utils.wordwrap')
 
 describe("utils::wordwrap", function()
   it("should work", function()


### PR DESCRIPTION
Currently, when you make changes to the code base in the `src` folder, Travis CI does **not** pick up these changes when running the test routines in the `spec`folder. The tests run on the system wide installation of `cliargs`(which is a dependency of `busted`) instead. I find this behaviour confusing.
The submitted patch request corrects this by modifying the load path in multiple `require`statements. IMHO this is an appropriate approach. I'm aware of the fact that this can be corrected by other means (like modifiying the `package.path` or so).